### PR TITLE
Add user agent string

### DIFF
--- a/aocdl/main.go
+++ b/aocdl/main.go
@@ -268,6 +268,7 @@ func download(config *configuration) error {
 	client := new(http.Client)
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://adventofcode.com/%d/day/%d/input", config.Year, config.Day), nil)
+	req.Header.Set("User-Agent", "github.com/GreenLightning/advent-of-code-downloader")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The creater of Advent of Code [has requested that all requests include a descriptive User-Agent string](https://www.reddit.com/r/adventofcode/comments/z9dhtd/please_include_your_contact_info_in_the_useragent/), as generic ones will potentially be blocked soon. This simple pull request adds a User-Agent string pointing to the GitHub repository.