### PR TITLE
feat: adding `config-path` flag 

### DIFF
--- a/aocdl/config.go
+++ b/aocdl/config.go
@@ -17,31 +17,39 @@ type configuration struct {
 	Wait          bool   `json:"-"`
 }
 
-func loadConfigs() (*configuration, error) {
+func loadConfigs(configPath string) (*configuration, error) {
 	config := new(configuration)
 
-	home := ""
-	usr, err := user.Current()
-	if err == nil {
-		home = usr.HomeDir
-	}
-
-	if home != "" {
-		err = config.mergeWithFileIfExists(filepath.Join(home, ".aocdlconfig"))
+	// If a config path was given, use it above any other defaults
+	if len(configPath) > 0 {
+		err := config.mergeWithFileIfExists(configPath)
 		if err != nil {
 			return nil, err
 		}
-	}
+	} else {
+		home := ""
+		usr, err := user.Current()
+		if err == nil {
+			home = usr.HomeDir
+		}
 
-	wd, _ := os.Getwd()
+		if home != "" {
+			err = config.mergeWithFileIfExists(filepath.Join(home, ".aocdlconfig"))
+			if err != nil {
+				return nil, err
+			}
+		}
 
-	// If we could not determine either directory or if we are not currently in
-	// the home directory, try and load the configuration relative to the
-	// current working directory.
-	if wd == "" || home == "" || wd != home {
-		err = config.mergeWithFileIfExists(".aocdlconfig")
-		if err != nil {
-			return nil, err
+		wd, _ := os.Getwd()
+
+		// If we could not determine either directory or if we are not currently in
+		// the home directory, try and load the configuration relative to the
+		// current working directory.
+		if wd == "" || home == "" || wd != home {
+			err = config.mergeWithFileIfExists(".aocdlconfig")
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
This change adds a `config-path` parameter to the program that allows for a custom config file path instead of just the current or home directory. A passed in config file will cause the program to skip loading files in either the current or home directory. Other config flags passed in still take priority over values in the custom config.

This was accomplished by:

1. Creating `startupFlags`, which is just a `configuration` struct with with a string tacked on for the `ConfigPath`.
2. Splitting `addFlags(config *configuration)` into `parseFlags() startupFlags` and `addFlags(flags startupFlags, config *configuration)`. 
    - `parseFlags` simply reads in the flags so we know `ConfigPath` ahead of loading the config file
    - `addFlags` overwrites any values in the config with those passed in as flags
3. Passing `ConfigPath` to `loadConfigs`
    - As mentioned before, passed in config takes priority over files in `~` and `.`

I also did a small refactor of the flag parsing, changing from using  `flags.String` across the board to `flags.StringVar` and `flags.IntVar` to avoid additional conversion from string to int. I will change this back if there are strong opinions about the previous parsing method.